### PR TITLE
fix: Use correct link

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -7,7 +7,7 @@
   "slug": "trainline",
   "source": "git@github.com:konnectors/cozy-konnector-trainline.git",
   "editor": "Cozy",
-  "vendor_link": "www.trainline.fr",
+  "vendor_link": "https://www.trainline.fr",
   "categories": [
     "transport"
   ],


### PR DESCRIPTION
Otherwise, when clicking on the website in the home, we do not arrive
on the right page.